### PR TITLE
Fixes for snapshotting & uploading them to S3

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -20,7 +20,9 @@
                  [org.apache.hbase/hbase-client ~hbase-version]
                  [org.apache.hbase/hbase-server ~hbase-version]
                  [org.apache.hbase/hbase-protocol ~hbase-version]
-                 [org.apache.hbase/hbase ~hbase-version :extension "pom"]]
+                 [org.apache.hbase/hbase ~hbase-version :extension "pom"]
+                 [org.apache.hadoop/hadoop-aws ~hadoop-version]
+                 [org.apache.httpcomponents/httpclient "4.5.4"]]
   :source-paths ["src/clj"]
   :java-source-paths ["src/java"]
   :aot :all)

--- a/src/clj/hbase/admin/core.clj
+++ b/src/clj/hbase/admin/core.clj
@@ -485,14 +485,14 @@
 (defn- mk-s3-url
   [with-creds? with-path? opts]
   (if with-creds?
-    (str (:s3-protocol opts) (:access-key opts) ":" (:secret-key opts) + "@" (:bucket opts) (when with-path? (:path opts)))
+    (str (:s3-protocol opts) (:access-key opts) ":" (:secret-key opts) "@" (:bucket opts) (when with-path? (:path opts)))
     (str (:s3-protocol opts) (:bucket opts) (when with-path? (:path opts)))))
 
 (defn- mk-toolrunner-args
   [{:keys [snapshot-name url-in url-out parallelism]}]
   (into-array
     (remove nil?
-    ["-snaspshot"
+    ["-snapshot"
      snapshot-name
      (when url-in "-copy-from")
      (when url-in url-in)


### PR DESCRIPTION
Hi,
I tried using `export-snapshot-to-s3`, but ran into a few problems when running `ExportSnapshot` due to some typos, and some dependencies issues (mostly around Hadoop's `S3AFileSystem` not being found).

This PR should fix those issues. I was able to export my snapshot to S3 following these fixes.

Thanks